### PR TITLE
add model-based logger

### DIFF
--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -374,6 +374,7 @@ void RAGreedy::enqueue(PQueue &CurQueue, const LiveInterval *LI) {
   *Evaluator->getTensor<int64_t>(0) = static_cast<int64_t>(Size);
   *Evaluator->getTensor<int64_t>(1) = static_cast<int64_t>(Stage);
   *Evaluator->getTensor<float>(2) = static_cast<float>(LI->weight());
+  float Ret = Evaluator->evaluate<float>();
 
   size_t CurrentFeature = 0;
   for (; CurrentFeature < FeatureList.size(); ++CurrentFeature) {
@@ -387,7 +388,7 @@ void RAGreedy::enqueue(PQueue &CurQueue, const LiveInterval *LI) {
           CurrentFeature,
           reinterpret_cast<const char *>(
               MUTR->lastEvaluationResult()->getUntypedTensorValue(I)));
-  float Ret = static_cast<float>(Prio);
+  Ret = static_cast<float>(Prio);
   Log->logFloatValue(CurrentFeature, &Ret);
 
   // The virtual register number is a tie breaker for same-sized ranges.

--- a/llvm/lib/CodeGen/RegAllocGreedy.h
+++ b/llvm/lib/CodeGen/RegAllocGreedy.h
@@ -156,7 +156,7 @@ public:
 
 private:
   // Convenient shortcuts.
-  using PQueue = std::priority_queue<std::pair<unsigned, unsigned>>;
+  using PQueue = std::priority_queue<std::pair<float, unsigned>>;
   using SmallLISet = SmallPtrSet<const LiveInterval *, 4>;
 
   // We need to track all tentative recolorings so we can roll back any


### PR DESCRIPTION
I try to add model-based logger. But it gives an error when running with the training model. 

Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  clang-15                 0x0000000110e2c21d llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  clang-15                 0x0000000110e2c79b PrintStackTraceSignalHandler(void*) + 27
2  clang-15                 0x0000000110e2a586 llvm::sys::RunSignalHandlers() + 134
3  clang-15                 0x0000000110e2baae llvm::sys::CleanupOnSignal(unsigned long) + 110
4  clang-15                 0x0000000110c3a724 (anonymous namespace)::CrashRecoveryContextImpl::HandleCrash(int, unsigned long) + 196
5  clang-15                 0x0000000110c3ab55 CrashRecoverySignalHandler(int) + 197
6  libsystem_platform.dylib 0x00007ff81582fdfd _sigtramp + 29
7  libsystem_platform.dylib 0x6e67696c6165726b _sigtramp + 7955302477495170187
8  clang-15                 0x000000010f31e8ec long long* llvm::MLModelRunner::getTensor<long long, int>(int) + 28
9  clang-15                 0x000000010f31e4d9 llvm::RAGreedy::enqueue(std::__1::priority_queue<std::__1::pair<unsigned int, unsigned int>, std::__1::vector<std::__1::pair<unsigned int, unsigned int>, std::__1::allocator<std::__1::pair<unsigned int, unsigned int> > >, std::__1::less<std::__1::pair<unsigned int, unsigned int> > >&, llvm::LiveInterval const*) + 873
10 clang-15                 0x000000010f31e167 llvm::RAGreedy::enqueueImpl(llvm::LiveInterval const*) + 39
11 clang-15                 0x000000010f2ed9c8 llvm::RegAllocBase::enqueue(llvm::LiveInterval const*) + 488
12 clang-15                 0x000000010f2ed7b2 llvm::RegAllocBase::seedLiveRegs() + 290
13 clang-15                 0x000000010f2edacd llvm::RegAllocBase::allocatePhysRegs() + 45
14 clang-15                 0x000000010f32ef63 llvm::RAGreedy::runOnMachineFunction(llvm::MachineFunction&) + 3747
15 clang-15                 0x000000010efbdd04 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) + 500
16 clang-15                 0x000000010f93ee64 llvm::FPPassManager::runOnFunction(llvm::Function&) + 628
17 clang-15                 0x000000010f946832 llvm::FPPassManager::runOnModule(llvm::Module&) + 114
18 clang-15                 0x000000010f93f759 (anonymous namespace)::MPPassManager::runOnModule(llvm::Module&) + 729
19 clang-15                 0x000000010f93f2cd llvm::legacy::PassManagerImpl::run(llvm::Module&) + 269
20 clang-15                 0x000000010f946ba1 llvm::legacy::PassManager::run(llvm::Module&) + 33
21 clang-15                 0x00000001115bcab7 (anonymous namespace)::EmitAssemblyHelper::RunCodegenPipeline(clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream> >&, std::__1::unique_ptr<llvm::ToolOutputFile, std::__1::default_delete<llvm::ToolOutputFile> >&) + 551
22 clang-15                 0x00000001115a9465 (anonymous namespace)::EmitAssemblyHelper::EmitAssembly(clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream> >) + 453
23 clang-15                 0x00000001115a8603 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, std::__1::unique_ptr<llvm::raw_pwrite_stream, std::__1::default_delete<llvm::raw_pwrite_stream> >) + 1139
24 clang-15                 0x0000000111ca4972 clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) + 2242
25 clang-15                 0x00000001153a4941 clang::ParseAST(clang::Sema&, bool, bool) + 897
26 clang-15                 0x00000001124f76ac clang::ASTFrontendAction::ExecuteAction() + 300
27 clang-15                 0x0000000111ca2a2c clang::CodeGenAction::ExecuteAction() + 92
28 clang-15                 0x00000001124f6ccc clang::FrontendAction::Execute() + 124
29 clang-15                 0x00000001123deed3 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) + 963
30 clang-15                 0x0000000112646f67 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) + 935
31 clang-15                 0x000000010bcdb97a cc1_main(llvm::ArrayRef<char const*>, char const*, void*) + 1530
32 clang-15                 0x000000010bccc89c ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&) + 380
33 clang-15                 0x00000001120adef5 clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, bool*) const::$_1::operator()() const + 37
34 clang-15                 0x00000001120adec5 void llvm::function_ref<void ()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, bool*) const::$_1>(long) + 21
35 clang-15                 0x0000000110c3a5b9 llvm::function_ref<void ()>::operator()() const + 25
36 clang-15                 0x0000000110c3a55c llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) + 236
37 clang-15                 0x00000001120a7e96 clang::driver::CC1Command::Execute(llvm::ArrayRef<llvm::Optional<llvm::StringRef> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, bool*) const + 534
38 clang-15                 0x0000000112035b42 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&) const + 770
39 clang-15                 0x0000000112035f48 clang::driver::Compilation::ExecuteJobs(clang::driver::JobList const&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*> >&) const + 152
40 clang-15                 0x0000000112055365 clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__1::pair<int, clang::driver::Command const*> >&) + 325
41 clang-15                 0x000000010bccbf14 main + 4596
42 dyld                     0x000000014412b51e start + 462